### PR TITLE
Fix coin area entering player still activating after tween

### DIFF
--- a/Chapter 2 - Coin Dash/Coin.gd
+++ b/Chapter 2 - Coin Dash/Coin.gd
@@ -13,7 +13,7 @@ func _ready():
 								Tween.EASE_IN_OUT)
 
 func pickup():
-	monitoring = false
+	monitorable = false
 	$Tween.start()
 
 func _on_Tween_tween_completed( object, key ):


### PR DESCRIPTION
From docs:
```
bool monitorable [default: true]set_monitorable(value) setteris_monitorable() getter

If true, other monitoring areas can detect this area.
```
```
bool monitoring [default: true]set_monitoring(value) setteris_monitoring() getter

If true, the area detects bodies or areas entering and exiting it.
```